### PR TITLE
Prevent multiple bundles when using chunk hash

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ HtmlWebpackMultiBuildPlugin.prototype = {
                     'HtmlWebpackMultiBuildPlugin',
                     this.beforeHtmlGeneration.bind(this),
                 );
+                compiler.hooks.watchRun.tap('HtmlWebpackMultiBuildPlugin', () => this.js.length = 0);
             });
         } else {
             compiler.plugin('compilation', compilation => {


### PR DESCRIPTION
When the outfile contains a chuckhash, the plugin will keep on adding the old bundles to the HTML output.
This changes that behavior.

Unfortunately, I'm not entirely sure how to fix this pre webpack 4. any assistance on that would be great.